### PR TITLE
Check label args for lambdas, not just named functions.

### DIFF
--- a/src/tc/infer.rs
+++ b/src/tc/infer.rs
@@ -152,10 +152,10 @@ impl Tc<'_> {
                 // closure introduction form admits row subsumption); a closed or
                 // rigid tail is pinned afterward so the body may not exceed it.
                 let eff = self.apply_row(eff);
-                let mut prefix = BTreeSet::new();
+                let mut prefix = Vec::new();
                 let mut cursor = &eff;
                 while let EffRow::Extend(l, more) = cursor {
-                    prefix.insert(l.name);
+                    prefix.push(l.clone());
                     cursor = more;
                 }
                 let (tail, closed) = match cursor {
@@ -464,7 +464,7 @@ impl Tc<'_> {
                 let checked = self.with_row_scope(
                     RowScope {
                         tail: row,
-                        prefix: BTreeSet::new(),
+                        prefix: Vec::new(),
                     },
                     |tc| tc.check(&env2, body, &Type::Exist(ret)),
                 );
@@ -1528,7 +1528,7 @@ impl Tc<'_> {
         let prefix = self
             .cur_row
             .as_ref()
-            .map_or_else(BTreeSet::new, |s| s.prefix.clone());
+            .map_or_else(Vec::new, |s| s.prefix.clone());
         let saved_row = self.cur_row.replace(RowScope {
             tail: body_row,
             prefix,
@@ -1795,7 +1795,7 @@ impl Tc<'_> {
         env2.insert(Sym::from(&d.name), self_entry);
         let saved_row = self.cur_row.replace(RowScope {
             tail: seed.mu,
-            prefix: BTreeSet::new(),
+            prefix: Vec::new(),
         });
         let checked = self.in_row_scope(&seed.scope, |tc| {
             tc.with_self(
@@ -1880,7 +1880,7 @@ impl Tc<'_> {
         let (r, effs) = self.with_row_scope(
             RowScope {
                 tail: mu,
-                prefix: BTreeSet::new(),
+                prefix: Vec::new(),
             },
             |tc| {
                 let r = f(tc);

--- a/src/tc/mod.rs
+++ b/src/tc/mod.rs
@@ -6,7 +6,7 @@ use crate::error::TypeError;
 use crate::sym::Sym;
 use crate::syntax::ast::{Core, Decl, Expr, Grade, NodeId, Program, S};
 use crate::types::effects;
-use crate::types::ty::{EffRow, Effects, Kind, Type};
+use crate::types::ty::{EffRow, Effects, Kind, Label, Type};
 
 mod classes;
 mod context;
@@ -370,10 +370,13 @@ struct SelfRef {
 
 // Open row existential tail plus the concrete labels in its fixed prefix.
 // Absorbing a callee row skips the prefix labels so a direct named call does
-// not duplicate a label.
+// not duplicate a label. The prefix keeps whole labels, not bare names: the
+// skip must equate a parametric label's arguments against the prefix's
+// instantiation, or a lambda body performing `Tag(String)` under an arrow
+// annotated `! {Tag(Int) | e}` would drop the label unchecked.
 struct RowScope {
     tail: u32,
-    prefix: BTreeSet<Sym>,
+    prefix: Vec<Label>,
 }
 
 // The concrete effects a declaration performs: the labels of its inferred

--- a/src/tc/subsume.rs
+++ b/src/tc/subsume.rs
@@ -393,8 +393,13 @@ impl Tc<'_> {
         if fv.contains(&cur_row) {
             return Ok(());
         }
-        // Labels already in the ambient's fixed prefix need not be re-added.
-        let eff = without_labels(&eff, &prefix);
+        // Labels already in the ambient's fixed prefix need not be re-added,
+        // but a parametric label's arguments must agree with the prefix's
+        // instantiation before it is dropped: skipping by name alone let a
+        // lambda body perform `Tag(String)` under an arrow annotated
+        // `! {Tag(Int) | e}` unchecked (the named-function path errors through
+        // `rewrite_row`'s argument equation; this is its prefix analogue).
+        let eff = self.strip_prefix(&eff, &prefix)?;
         let opened = if matches!(eff.tail(), EffRow::Empty) {
             let fresh = self.push_ex_row();
             replace_tail(&eff, EffRow::Exist(fresh))
@@ -403,6 +408,33 @@ impl Tc<'_> {
         };
         let amb = EffRow::Exist(cur_row);
         self.unify_row(&opened, &amb)
+    }
+
+    // Drop the labels the fixed prefix already carries, equating a dropped
+    // label's type arguments against the prefix's instantiation (first
+    // name-match wins, mirroring `rewrite_row`). Labels not in the prefix pass
+    // through for the tail unification in `absorb_row`.
+    fn strip_prefix(&mut self, r: &EffRow, prefix: &[Label]) -> Result<EffRow, TcErr> {
+        match r {
+            EffRow::Extend(l, rest) => {
+                let rest = self.strip_prefix(rest, prefix)?;
+                let Some(p) = prefix.iter().find(|p| p.name == l.name) else {
+                    return Ok(EffRow::Extend(l.clone(), Box::new(rest)));
+                };
+                for (x, y) in l.args.iter().zip(&p.args) {
+                    let (lx, ly) = (l.clone(), p.clone());
+                    self.equate(x, y).map_err(|e| {
+                        e.or_fail(format!(
+                            "effect instantiation mismatch: `{}` is not compatible with `{}`",
+                            self.show_label(&lx),
+                            self.show_label(&ly)
+                        ))
+                    })?;
+                }
+                Ok(rest)
+            }
+            other => Ok(other.clone()),
+        }
     }
 
     // After a handler body accumulated into `body_row`, fold its row minus the

--- a/tests/cases/eff_label_arg_prefix.pr
+++ b/tests/cases/eff_label_arg_prefix.pr
@@ -1,0 +1,12 @@
+-- A lambda checked against an annotated arrow row must equate a parametric
+-- label's type arguments, not skip the label by name: performing `Tag(String)`
+-- under an expected `! {Tag(Int) | e}` is a type error. The named-function
+-- path always errored through `rewrite_row`'s argument equation; the fixed
+-- prefix skip in `absorb_row` used to drop the lambda form unchecked, so the
+-- mismatch only surfaced at run time inside the eventual handler.
+effect Tag(a)
+  ctl put(a) : Unit
+
+fn wants_int(s : (Unit) -> Unit ! {Tag(Int) | e}) : Int = 1
+
+fn main() = println(wants_int(\(_u) -> put("hi")))

--- a/tests/snapshots/snapshots__pipeline@eff_label_arg_prefix.pr.snap
+++ b/tests/snapshots/snapshots__pipeline@eff_label_arg_prefix.pr.snap
@@ -1,0 +1,162 @@
+---
+source: tests/snapshots.rs
+expression: "prism::report(&src)"
+input_file: tests/cases/eff_label_arg_prefix.pr
+---
+== tokens ==
+VOpen Effect UIdent("Tag") LParen Ident("a") RParen VOpen Ctl Ident("put") LParen Ident("a") RParen Colon KwUnit VClose VSemi Fn Ident("wants_int") LParen Ident("s") Colon LParen KwUnit RParen Arrow KwUnit Bang LBrace UIdent("Tag") LParen KwInt RParen Bar Ident("e") RBrace RParen Colon KwInt Eq Int(IntLit { value: 1, suffix: None }) VSemi Fn Ident("main") LParen RParen Eq Ident("println") LParen Ident("wants_int") LParen Lambda LParen Ident("_u") RParen Arrow Ident("put") LParen StringLit("hi") RParen RParen RParen VClose
+
+== ast ==
+Program {
+    types: [],
+    effects: [
+        EffectDecl {
+            name: "Tag",
+            params: [
+                "a",
+            ],
+            ops: [
+                EffOp {
+                    name: "put",
+                    params: [
+                        Var(
+                            "a",
+                        ),
+                    ],
+                    ret: Unit,
+                    grade: Many,
+                },
+            ],
+            span: 453..486,
+        },
+    ],
+    errors: [],
+    aliases: [],
+    classes: [],
+    instances: [],
+    fns: [
+        Decl {
+            name: "wants_int",
+            params: [
+                Param {
+                    name: "s",
+                    ty: Some(
+                        Fun(
+                            [
+                                Unit,
+                            ],
+                            Cons(
+                                [
+                                    EffLabel {
+                                        name: "Tag",
+                                        args: [
+                                            Int,
+                                        ],
+                                    },
+                                ],
+                                Some(
+                                    "e",
+                                ),
+                            ),
+                            Unit,
+                        ),
+                    ),
+                    borrow: false,
+                    default: None,
+                },
+            ],
+            ret: Some(
+                Int,
+            ),
+            eff: None,
+            constraints: [],
+            body: Spanned {
+                node: Int(
+                    IntLit {
+                        value: 1,
+                        suffix: None,
+                    },
+                ),
+                span: 546..547,
+            },
+            wheres: [],
+            span: 488..547,
+        },
+        Decl {
+            name: "main",
+            params: [],
+            ret: None,
+            eff: None,
+            constraints: [],
+            body: Spanned {
+                node: Call(
+                    Spanned {
+                        node: Var(
+                            "println",
+                        ),
+                        span: 561..568,
+                    },
+                    [
+                        Spanned {
+                            node: Call(
+                                Spanned {
+                                    node: Var(
+                                        "wants_int",
+                                    ),
+                                    span: 569..578,
+                                },
+                                [
+                                    Spanned {
+                                        node: Lam(
+                                            [
+                                                Param {
+                                                    name: "_u",
+                                                    ty: None,
+                                                    borrow: false,
+                                                    default: None,
+                                                },
+                                            ],
+                                            Spanned {
+                                                node: Call(
+                                                    Spanned {
+                                                        node: Var(
+                                                            "put",
+                                                        ),
+                                                        span: 588..591,
+                                                    },
+                                                    [
+                                                        Spanned {
+                                                            node: Str(
+                                                                "hi",
+                                                            ),
+                                                            span: 592..596,
+                                                        },
+                                                    ],
+                                                ),
+                                                span: 588..597,
+                                            },
+                                        ),
+                                        span: 579..597,
+                                    },
+                                ],
+                            ),
+                            span: 569..598,
+                        },
+                    ],
+                ),
+                span: 561..599,
+            },
+            wheres: [],
+            span: 549..599,
+        },
+    ],
+}
+
+== types ==
+Type Error: in `main`: type mismatch: expected Int, got String
+    ╭─[ <source>:12:44 ]
+    │
+ 12 │ fn main() = println(wants_int(\(_u) -> put("hi")))
+    │                                            ──┬─  
+    │                                              ╰─── in `main`: type mismatch: expected Int, got String
+────╯


### PR DESCRIPTION
This is an issue for lambas only, *not* named functions, because lambdas are treated differently in infer.rs. Named functions are are checked by `rewrite_row` which already checked labels correctly.

In `absorb_row`, we now check the whole label rather than just the effect name.